### PR TITLE
[fixed] cardheader white on grey text color

### DIFF
--- a/public/css/shared.css
+++ b/public/css/shared.css
@@ -718,7 +718,9 @@ a{
 /*+++++++++++++++++++++++++++++++++++++++++++*/
 .custom-card-header{
     background-image: linear-gradient(270deg, #145f9c 0%, rgb(12, 81, 138) 100%);
+    color:#fff !important;
 }
+
 .custom-card-header h6{
     color: white ;
     font-weight: 400 !important;

--- a/resources/views/components/generalCard.edge
+++ b/resources/views/components/generalCard.edge
@@ -8,9 +8,9 @@
 
 <div class="card shadow" style='height:100%;'>
     {{--  grabs title from params and outputs within the header  --}}
-    <div class="card-header py-3 d-flex color-primary {{extraCSS}}">
+    <div class="card-header py-3 d-flex text-primary {{extraCSS}}">
         <div class='flex-grow-1 d-flex align-content-center'>
-            <h2 class="h6 m-0 font-weight-bold text-white"><i class='{{icon}}'></i> {{ title }}</h2>
+            <h2 class="h6 m-0 font-weight-bold"><i class='{{icon}}'></i> {{ title }}</h2>
         </div>
         <div class='text-right'>
             @if($slot.titleRight)


### PR DESCRIPTION
- card headers with grey backgrounds were showing white text
- now the default text-color is  dark blue