### PR TITLE
[fixed] search results not loading with back button

### DIFF
--- a/resources/views/userPages/fixedSearchResults.edge
+++ b/resources/views/userPages/fixedSearchResults.edge
@@ -12,11 +12,14 @@
 @section('content')
         {{--  Loading page header  --}}
         @!component('components.pageHeader', title=antl.formatMessage('searchResults.pageTitleFixedSearch'), subtitle=antl.formatMessage('searchResults.subtitle'), loading=false)
-
+        
         @if(roomsLength == 0)
             {{--  Loading result empty card  --}}
             @!component('components.cardEmptyMessage', {faIcon:"fas fa-ghost fa-8x mb-4 mt-3", message:"No rooms available"})
         @else
+            {{--  used to detect if page refresh required  --}}
+            <input type="hidden" id="refresh" value="no">
+
             {{--  Loading spinning wheel  --}}
             @!component('components.searchLoadingSpinner', {message:antl.formatMessage('searchResults.searching')})
 
@@ -114,6 +117,12 @@
                         }
                     }
                 }, 1000);
+            });
+
+            //reload page to refresh results if user used the back button ot get to resutls page
+            $(document).ready(function(e) {
+                var $input = $('#refresh');
+                $input.val() == 'yes' ? location.reload(true) : $input.val('yes');
             });
         </script>
     @endif

--- a/resources/views/userPages/flexibleSearchResults.edge
+++ b/resources/views/userPages/flexibleSearchResults.edge
@@ -17,6 +17,9 @@
         {{--  Loading result empty card  --}}
         @!component('components.cardEmptyMessage', {faIcon:"fas fa-ghost fa-8x mb-4 mt-3", message:"No rooms available"})
     @else
+        {{--  used to detect if page refresh required  --}}
+        <input type="hidden" id="refresh" value="no">
+        
         {{--  Loading spinning wheel  --}}
         @!component('components.searchLoadingSpinner',  {message:antl.formatMessage('searchResults.searching')})
 
@@ -128,6 +131,11 @@
                 }, 1000);
             });
 
+            //reload page to refresh results if user used the back button ot get to resutls page
+            $(document).ready(function(e) {
+                var $input = $('#refresh');
+                $input.val() == 'yes' ? location.reload(true) : $input.val('yes');
+            });
         </script>
     @endif
 @endsection


### PR DESCRIPTION
- search page would get stuck on spinner when user used back button
- needed to auto reload the page re-trigger the search
- code detects if page is fresh or has been loaded from cache
- if it was loaded from cache it forces a reload